### PR TITLE
Fix site configuration link

### DIFF
--- a/index.html
+++ b/index.html
@@ -266,7 +266,7 @@
   <div class="wrap prose" data-reveal>
     <h3>Make it yours</h3>
     <p>The parts that belong to your organisation rather than to the app - the identity provider your APIs sign in against, your environments, your Grafana instances, the skills marketplace, the commands worth having on hand - all live in one optional settings file the app reads at startup. Every section is optional, and so is the file.</p>
-    <p>The first-launch wizard can read it from a local file or clone it from a Git repository, and <code>build-app.sh</code> can fold it into the bundle so the app you hand to your team is already set up. See the <a href="https://github.com/teya-engineering/code-station#site-configuration">site configuration guide</a> and <a href="https://github.com/teya-engineering/code-station/blob/main/site-defaults.example.json">the blank-slate example</a>.</p>
+    <p>The first-launch wizard can read it from a local file or clone it from a Git repository, and <code>build-app.sh</code> can fold it into the bundle so the app you hand to your team is already set up. See the <a href="https://github.com/teya-engineering/code-station/blob/main/docs/site-configuration.md">site configuration guide</a> and <a href="https://github.com/teya-engineering/code-station/blob/main/site-defaults.example.json">the blank-slate example</a>.</p>
   </div>
 </section>
 


### PR DESCRIPTION
Point the GitHub Pages site configuration link directly to the guide in the main branch. The blank-slate example link is already correct and remains unchanged.