### PR TITLE
Add signed release pipeline (Developer ID + notarization + DMG)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,95 @@
+name: Release
+
+# Publica um DMG assinado e notarizado sempre que fizeres push de uma tag v*.
+#   git tag v1.2.0 && git push origin v1.2.0
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Versao a construir (ex.: 1.2.0)'
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: macos-15
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Determinar versao
+        id: v
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+          fi
+
+      # O macos-15 ja traz Xcode 16.x (Swift 6) por omissao. Se um dia precisares
+      # de fixar a versao, descomenta o passo maxim-lobanov/setup-xcode.
+      # - uses: maxim-lobanov/setup-xcode@v1
+      #   with:
+      #     xcode-version: '16.4'
+      - name: Toolchain
+        run: swift --version && xcodebuild -version
+
+      - name: Importar certificado Developer ID
+        env:
+          CERT_P12: ${{ secrets.MACOS_CERTIFICATE_P12 }}
+          CERT_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+        run: |
+          KEYCHAIN="$RUNNER_TEMP/build.keychain-db"
+          KEYCHAIN_PASSWORD="$(uuidgen)"
+
+          echo "$CERT_P12" | base64 --decode > "$RUNNER_TEMP/cert.p12"
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security set-keychain-settings -lut 3600 "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security import "$RUNNER_TEMP/cert.p12" \
+            -k "$KEYCHAIN" -P "$CERT_PASSWORD" \
+            -T /usr/bin/codesign -T /usr/bin/security
+          # Sem isto o codesign para a pedir a password numa UI que nao existe.
+          security set-key-partition-list -S apple-tool:,apple:,codesign: \
+            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN" >/dev/null
+          security list-keychain -d user -s "$KEYCHAIN" login.keychain-db
+
+          rm -f "$RUNNER_TEMP/cert.p12"
+          security find-identity -v -p codesigning "$KEYCHAIN"
+
+      - name: Escrever chave da API do App Store Connect
+        env:
+          AC_API_KEY_P8: ${{ secrets.AC_API_KEY_P8 }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/private_keys"
+          echo "$AC_API_KEY_P8" | base64 --decode \
+            > "$RUNNER_TEMP/private_keys/AuthKey.p8"
+
+      - name: Build, assinar, notarizar, empacotar
+        env:
+          AC_API_KEY_PATH: ${{ runner.temp }}/private_keys/AuthKey.p8
+          AC_API_KEY_ID: ${{ secrets.AC_API_KEY_ID }}
+          AC_API_ISSUER_ID: ${{ secrets.AC_API_ISSUER_ID }}
+          TEAM_ID: QZG8V8U2Y6
+          BUILD_NUMBER: ${{ github.run_number }}
+        run: ./Scripts/release.sh "${{ steps.v.outputs.version }}"
+
+      - name: Limpar segredos do runner
+        if: always()
+        run: rm -rf "$RUNNER_TEMP/private_keys" "$RUNNER_TEMP/build.keychain-db"
+
+      - name: Publicar a GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: Teya Code Station ${{ steps.v.outputs.version }}
+          draft: true          # revê antes de tornar publica
+          generate_release_notes: true
+          files: |
+            build/TeyaCodeStation-${{ steps.v.outputs.version }}.dmg
+            build/TeyaCodeStation-${{ steps.v.outputs.version }}.dmg.sha256

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,8 +8,8 @@ Team ID: `QZG8V8U2Y6` · Bundle ID: `com.teya.code-station`
 
 - [x] Certificado **Developer ID Application — Teya Services Limited**, válido até 2031-09-01
 - [x] Certificado descarregado e instalado na Keychain
-- [ ] Chave de API do App Store Connect no sítio certo
-- [ ] Primeira release manual
+- [x] Chave de API do App Store Connect no sítio certo (`~/private_keys/AuthKey_2VM7JH4JUA.p8`)
+- [x] Primeira release manual (1.0.0, notarizada e validada com quarentena a 2026-08-31)
 - [ ] Workflow de CI
 
 ## 1. Instalar o certificado

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,112 @@
+# Publicar o Teya Code Station
+
+Distribuição fora da App Store: **Developer ID Application + hardened runtime + notarização + DMG**. Sem isto, quem faz download vê *"não pode ser aberto porque a Apple não conseguiu verificar se contém software malicioso"*.
+
+Team ID: `QZG8V8U2Y6` · Bundle ID: `com.teya.code-station`
+
+## 0. O que já está feito
+
+- [x] Certificado **Developer ID Application — Teya Services Limited**, válido até 2031-09-01
+- [x] Certificado descarregado e instalado na Keychain
+- [ ] Chave de API do App Store Connect no sítio certo
+- [ ] Primeira release manual
+- [ ] Workflow de CI
+
+## 1. Instalar o certificado
+
+Na página do certificado, clica **Download**, depois duplo-clique no `.cer`. Confirma:
+
+```bash
+security find-identity -v -p codesigning
+```
+
+Tem de aparecer:
+
+```
+1) ABC123… "Developer ID Application: Teya Services Limited (QZG8V8U2Y6)"
+```
+
+Se aparecer o certificado mas o `codesign` falhar com *"no identity found"*, é porque a chave privada não está nesta máquina. A chave privada só existe no Mac onde geraste o `.certSigningRequest`. Nesse caso, exporta de lá o par certificado+chave como `.p12`.
+
+## 2. Chave de API do App Store Connect
+
+Guarda o `.p8` fora do repositório (ex.: `~/private_keys/AuthKey_XXXXXXXXXX.p8`). Precisas de três coisas: o ficheiro, o **Key ID** e o **Issuer ID** (App Store Connect → Users and Access → Integrations → Keys).
+
+## 3. Ficheiros a adicionar ao repo
+
+```
+Resources/CodeStation.entitlements   # hardened runtime, mínimo
+Scripts/release.sh                   # build → assinar → notarizar → DMG
+.github/workflows/release.yml        # o mesmo, em CI, por tag
+```
+
+## 4. Release manual (faz esta primeiro)
+
+```bash
+export AC_API_KEY_PATH=~/private_keys/AuthKey_XXXXXXXXXX.p8
+export AC_API_KEY_ID=XXXXXXXXXX
+export AC_API_ISSUER_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+
+./Scripts/release.sh 1.0.0
+```
+
+O script faz, por esta ordem:
+
+1. `./build-app.sh release`
+2. escreve a versão no `Info.plist`
+3. reassina tudo com Developer ID, `--options runtime --timestamp` (substitui a assinatura ad-hoc do `build-app.sh`)
+4. `notarytool submit --wait` da `.app` → `stapler staple`
+5. cria o DMG com atalho para `/Applications`, assina, notariza e faz staple
+6. valida com `spctl` e escreve o SHA-256
+
+Demora tipicamente 5–15 minutos, quase tudo à espera da Apple.
+
+### O teste que interessa
+
+**Não testes no Mac onde compilaste** — não tem quarentena. Manda o DMG para outra máquina (ou simula):
+
+```bash
+xattr -w com.apple.quarantine "0081;00000000;Safari;" TeyaCodeStation-1.0.0.dmg
+```
+
+Depois abre normalmente. Tem de abrir sem avisos e sem botão direito → Abrir.
+
+## 5. Automatizar
+
+Secrets a criar em Settings → Secrets and variables → Actions:
+
+| Secret | Como obter |
+|---|---|
+| `MACOS_CERTIFICATE_P12` | Keychain Access → certificado + chave → Export `.p12` → `base64 -i cert.p12 \| pbcopy` |
+| `MACOS_CERTIFICATE_PASSWORD` | a password que puseste ao exportar o `.p12` |
+| `AC_API_KEY_P8` | `base64 -i AuthKey_XXXX.p8 \| pbcopy` |
+| `AC_API_KEY_ID` | Key ID (10 caracteres) |
+| `AC_API_ISSUER_ID` | Issuer ID (UUID) |
+
+Depois:
+
+```bash
+git tag v1.0.0 && git push origin v1.0.0
+```
+
+O workflow cria uma **draft release** com o DMG e o `.sha256`. Revês e publicas.
+
+## 6. Actualizar a página
+
+https://teya-engineering.github.io/code-station/ diz hoje para clonar e correr `./build-app.sh`. Depois da primeira release, o caminho principal passa a ser:
+
+- botão de download apontando para `https://github.com/teya-engineering/code-station/releases/latest`
+- requisitos: macOS 14+
+- build a partir do código passa a ser a secção "para contribuidores"
+
+Nota: o `build-app.sh` injecta `site-defaults.json` no bundle. Decide se a build pública leva defaults ou vai sem configuração — o que for para dentro do `.app` fica assinado e é distribuído a toda a gente.
+
+## Problemas comuns
+
+| Sintoma | Causa |
+|---|---|
+| `notarytool` devolve `Invalid` | corre `xcrun notarytool log <id> --key … --key-id … --issuer …`; quase sempre é um binário sem hardened runtime ou sem secure timestamp |
+| App crasha só depois de assinada | falta um entitlement — vê os comentários em `CodeStation.entitlements` e acrescenta um de cada vez |
+| `The signature does not include a secure timestamp` | faltou `--timestamp`, ou a máquina não tinha rede ao assinar |
+| `spctl` diz `rejected` mesmo notarizado | esqueceste o `stapler staple`, ou testaste um ficheiro sem quarentena |
+| Erro de keychain em CI | falta o `security set-key-partition-list` |

--- a/Resources/CodeStation.entitlements
+++ b/Resources/CodeStation.entitlements
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!--
+      Deliberadamente minimo. O hardened runtime e' obrigatorio para notarizar.
+      A app nao esta em sandbox, por isso rede, ficheiros e spawn de processos
+      (codex / claude, git, shell) funcionam sem entitlements nenhuns.
+
+      Se depois de assinar a app rebentar ao arrancar ou ao lancar um agente,
+      acrescenta SO a que for precisa, uma de cada vez:
+
+      <key>com.apple.security.cs.allow-jit</key><true/>
+          -> so se a propria app compilar codigo em runtime (nao e' o caso
+             dos agentes: esses sao processos filhos com assinatura propria).
+
+      <key>com.apple.security.cs.disable-library-validation</key><true/>
+          -> so se a app carregar dylibs/plugins de terceiros nao assinados
+             pela mesma Team ID.
+
+      <key>com.apple.security.cs.allow-dyld-environment-variables</key><true/>
+          -> so se definires DYLD_* para os processos filhos.
+
+      <key>com.apple.security.automation.apple-events</key><true/>
+          -> so se a app enviar Apple Events (ex.: controlar o Terminal.app).
+
+      Cada entitlement destes enfraquece o hardened runtime. Nao os metas
+      "por seguranca" - mete-os por sintoma.
+    -->
+</dict>
+</plist>

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -32,10 +32,10 @@ ENTITLEMENTS="Resources/CodeStation.entitlements"
 : "${AC_API_KEY_ID:?falta AC_API_KEY_ID}"
 : "${AC_API_ISSUER_ID:?falta AC_API_ISSUER_ID}"
 
-NOTARY=(xcrun notarytool
-        --key "$AC_API_KEY_PATH"
-        --key-id "$AC_API_KEY_ID"
-        --issuer "$AC_API_ISSUER_ID")
+# As credenciais vao DEPOIS do subcomando: "notarytool submit <file> --key ..."
+NOTARY_ARGS=(--key "$AC_API_KEY_PATH"
+             --key-id "$AC_API_KEY_ID"
+             --issuer "$AC_API_ISSUER_ID")
 
 step() { printf '\n\033[1m==> %s\033[0m\n' "$1"; }
 
@@ -90,7 +90,7 @@ step "A notarizar a app (pode demorar 1-15 min)"
 ZIP="build/$APP_NAME-notarize.zip"
 rm -f "$ZIP"
 /usr/bin/ditto -c -k --keepParent "$APP" "$ZIP"
-"${NOTARY[@]}" submit "$ZIP" --wait
+xcrun notarytool submit "$ZIP" --wait "${NOTARY_ARGS[@]}"
 xcrun stapler staple "$APP"
 rm -f "$ZIP"
 
@@ -108,7 +108,7 @@ rm -rf "$STAGE"
 
 step "A assinar e notarizar o DMG"
 codesign --force --sign "$IDENTITY" --timestamp "$DMG"
-"${NOTARY[@]}" submit "$DMG" --wait
+xcrun notarytool submit "$DMG" --wait "${NOTARY_ARGS[@]}"
 xcrun stapler staple "$DMG"
 
 # ---------------------------------------------------------------- 5. validar

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+# Assina, notariza e empacota o Teya Code Station para distribuicao fora da App Store.
+#
+# Requisitos no Mac (ou no runner):
+#   - Certificado "Developer ID Application: Teya Services Limited (QZG8V8U2Y6)" na keychain
+#   - Chave de API do App Store Connect (.p8) com role Developer ou superior
+#   - Xcode command line tools (codesign, notarytool, stapler, hdiutil)
+#
+# Uso:
+#   export AC_API_KEY_PATH=~/private_keys/AuthKey_XXXXXXXXXX.p8
+#   export AC_API_KEY_ID=XXXXXXXXXX
+#   export AC_API_ISSUER_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+#   ./Scripts/release.sh 1.2.0
+#
+set -euo pipefail
+
+VERSION="${1:-}"
+if [ -z "$VERSION" ]; then
+    echo "uso: $0 <versao>   (ex.: $0 1.2.0)" >&2
+    exit 1
+fi
+BUILD_NUMBER="${BUILD_NUMBER:-$(date +%Y%m%d%H%M)}"
+
+APP_NAME="Teya Code Station"
+APP="build/$APP_NAME.app"
+DMG="build/TeyaCodeStation-$VERSION.dmg"
+TEAM_ID="${TEAM_ID:-QZG8V8U2Y6}"
+IDENTITY="${SIGN_IDENTITY:-Developer ID Application: Teya Services Limited ($TEAM_ID)}"
+ENTITLEMENTS="Resources/CodeStation.entitlements"
+
+: "${AC_API_KEY_PATH:?falta AC_API_KEY_PATH (caminho para o .p8)}"
+: "${AC_API_KEY_ID:?falta AC_API_KEY_ID}"
+: "${AC_API_ISSUER_ID:?falta AC_API_ISSUER_ID}"
+
+NOTARY=(xcrun notarytool
+        --key "$AC_API_KEY_PATH"
+        --key-id "$AC_API_KEY_ID"
+        --issuer "$AC_API_ISSUER_ID")
+
+step() { printf '\n\033[1m==> %s\033[0m\n' "$1"; }
+
+# ---------------------------------------------------------------- 1. build
+step "A construir $APP_NAME $VERSION ($BUILD_NUMBER)"
+./build-app.sh release
+
+/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $VERSION" "$APP/Contents/Info.plist"
+/usr/libexec/PlistBuddy -c "Set :CFBundleVersion $BUILD_NUMBER"       "$APP/Contents/Info.plist"
+
+# ---------------------------------------------------------------- 2. assinar
+# O build-app.sh deixa uma assinatura ad-hoc. Substitui-se por Developer ID,
+# de dentro para fora: primeiro tudo o que esta encaixado, depois a app.
+step "A assinar com: $IDENTITY"
+
+sign() {
+    codesign --force \
+             --sign "$IDENTITY" \
+             --options runtime \
+             --timestamp \
+             --entitlements "$ENTITLEMENTS" \
+             "$@"
+}
+
+# Nested bundles, frameworks e binarios soltos primeiro (nunca uses --deep:
+# a Apple desaconselha-o e nao aplica entitlements aos nested correctamente).
+# Bundles so de recursos (ex.: MenuBarApp_MenuBarApp.bundle, sem Mach-O) nao
+# sao assinaveis; ficam selados pela assinatura da app.
+has_macho() {
+    [ -n "$(find "$1" -type f -exec sh -c 'file -b "$0" 2>/dev/null | grep -q Mach-O' {} \; -print -quit)" ]
+}
+
+while IFS= read -r -d '' nested; do
+    if ! has_macho "$nested"; then
+        echo "    sem codigo, salto: ${nested#$APP/}"
+        continue
+    fi
+    echo "    nested: ${nested#$APP/}"
+    sign "$nested"
+done < <(find "$APP/Contents" \
+              \( -name '*.framework' -o -name '*.bundle' -o -name '*.dylib' -o -name '*.so' \) \
+              -print0 | sort -rz)
+
+sign "$APP"
+
+step "A verificar a assinatura"
+codesign --verify --strict --deep --verbose=2 "$APP"
+codesign --display --verbose=4 "$APP" 2>&1 | grep -E 'Authority|TeamIdentifier|flags|Timestamp'
+
+# ---------------------------------------------------------------- 3. notarizar a app
+step "A notarizar a app (pode demorar 1-15 min)"
+ZIP="build/$APP_NAME-notarize.zip"
+rm -f "$ZIP"
+/usr/bin/ditto -c -k --keepParent "$APP" "$ZIP"
+"${NOTARY[@]}" submit "$ZIP" --wait
+xcrun stapler staple "$APP"
+rm -f "$ZIP"
+
+# ---------------------------------------------------------------- 4. DMG
+step "A criar o DMG"
+STAGE="$(mktemp -d)"
+cp -R "$APP" "$STAGE/"
+ln -s /Applications "$STAGE/Applications"
+rm -f "$DMG"
+hdiutil create -volname "$APP_NAME" \
+               -srcfolder "$STAGE" \
+               -fs HFS+ -format UDZO -ov \
+               "$DMG"
+rm -rf "$STAGE"
+
+step "A assinar e notarizar o DMG"
+codesign --force --sign "$IDENTITY" --timestamp "$DMG"
+"${NOTARY[@]}" submit "$DMG" --wait
+xcrun stapler staple "$DMG"
+
+# ---------------------------------------------------------------- 5. validar
+step "Validacao final (e' isto que o Gatekeeper vai ver)"
+xcrun stapler validate "$DMG"
+spctl --assess --type open --context context:primary-signature -vv "$DMG"
+spctl --assess --type execute -vv "$APP"
+
+shasum -a 256 "$DMG" | tee "$DMG.sha256"
+
+printf '\n\033[1;32mPronto:\033[0m %s\n' "$DMG"


### PR DESCRIPTION
Everything needed to ship a Gatekeeper-clean DMG instead of the ad-hoc `build-app.sh` signature:

- `Scripts/release.sh` — build → sign (Developer ID, hardened runtime, timestamp) → notarize → staple → DMG → validate. Run manually with the App Store Connect API key env vars (see `RELEASE.md`).
- `Resources/CodeStation.entitlements` — deliberately empty; the app is not sandboxed, so agents/git/shell work without any. Candidates are commented in the file for add-one-at-a-time debugging.
- `.github/workflows/release.yml` — same pipeline in CI on `v*` tags, publishing a draft GitHub Release with the DMG + SHA-256. Needs the 5 secrets listed in `RELEASE.md` §5.
- `RELEASE.md` — runbook, including the quarantine-xattr test and common notarization failures.

Validated end to end on 2026-08-31: release 1.0.0 built, both notarizations **Accepted**, stapled, `spctl` accepts the DMG and app **with the quarantine xattr set**, and the signed app launches with the empty entitlements. Two bugs found and fixed during that run: resource-only bundles (`MenuBarApp_MenuBarApp.bundle`) are unsignable and aborted the nested-signing loop under `set -e`, and `notarytool` requires credentials after the subcommand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EKZt6tbe4WEBsdPWYZQr6g