### PR TITLE
Point the site at the notarized DMG download

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
     <h1 data-reveal>Your agents just got<br><em>a headquarters.</em></h1>
     <p class="reveal--delay-1" data-reveal>Run Codex and Claude Code across every project - conversation, changes, files, and terminal in one window.</p>
     <div class="actions reveal--delay-2" data-reveal>
-      <a class="btn btn--primary" href="#get-started">Build the app</a>
+      <a class="btn btn--primary" href="https://github.com/teya-engineering/code-station/releases/latest">Download for macOS</a>
       <a class="btn btn--ghost" href="https://github.com/teya-engineering/code-station">View source</a>
     </div>
   </div>
@@ -165,8 +165,11 @@
 
 <section class="band band--light band--flat" id="get-started">
   <div class="pitch">
-    <h2 data-reveal>Clone it.<br><em>Run it.</em></h2>
-    <p class="reveal--delay-1" data-reveal>The build script makes a double-clickable, ad-hoc signed bundle you can drop in Applications.</p>
+    <h2 data-reveal>Download it.<br><em>Open it.</em></h2>
+    <p class="reveal--delay-1" data-reveal>A signed and notarized DMG. Drag the app to Applications and launch it - no toolchain, no build step.</p>
+    <div class="actions reveal--delay-2" data-reveal>
+      <a class="btn btn--primary" href="https://github.com/teya-engineering/code-station/releases/latest">Download for macOS</a>
+    </div>
   </div>
 
   <div class="wrap columns">
@@ -174,10 +177,10 @@
       <p class="eyebrow">What you need</p>
       <ul class="checklist">
         <li>macOS 14 or later</li>
-        <li>Xcode 16 or another Swift 6 toolchain</li>
-        <li>Git</li>
         <li>At least one agent installed and signed in: <code>codex</code> or <code>claude</code></li>
       </ul>
+      <p class="eyebrow" style="margin-top:36px">For contributors</p>
+      <p>Building from source needs Xcode 16 (or another Swift 6 toolchain) and Git. The script makes a double-clickable bundle you can drop in Applications.</p>
     </div>
 
     <div class="terminal" data-reveal="right">


### PR DESCRIPTION
After the first release, downloading becomes the primary path on https://teya-engineering.github.io/code-station/:

- Hero CTA changes from "Build the app" to **Download for macOS**, linking to `releases/latest`.
- The Get started section becomes "Download it. Open it." — signed and notarized DMG, requirements trimmed to macOS 14+ and an installed agent.
- Building from source moves to a "For contributors" note next to the (unchanged) `build-app.sh` terminal block.

Depends on the first GitHub Release being published (companion PR: #11) — until then the button 404s, so merge after the v1.0.0 release exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EKZt6tbe4WEBsdPWYZQr6g