### PR TITLE
Use posix_spawn_file_actions_addchdir_np unconditionally

### DIFF
--- a/Sources/MenuBarApp/CommandRunner.swift
+++ b/Sources/MenuBarApp/CommandRunner.swift
@@ -291,12 +291,11 @@ enum CommandRunner {
             throw RunError.launch("Could not connect the child process streams.")
         }
         if let currentDirectory {
+            // The unsuffixed posix_spawn_file_actions_addchdir only exists in the
+            // macOS 26 SDK, so building with an older SDK (CI) fails to find it.
+            // The _np variant is available since 10.15 and remains on 26.
             let result = currentDirectory.path.withCString {
-                if #available(macOS 26.0, *) {
-                    posix_spawn_file_actions_addchdir(&actions, $0)
-                } else {
-                    posix_spawn_file_actions_addchdir_np(&actions, $0)
-                }
+                posix_spawn_file_actions_addchdir_np(&actions, $0)
             }
             guard result == 0 else {
                 throw RunError.launch(String(cString: strerror(result)))


### PR DESCRIPTION
The v1.0.0 release workflow failed to compile on the macos-15 runner: the unsuffixed `posix_spawn_file_actions_addchdir` only exists in the macOS 26 SDK, and `#available` is a runtime check, so older SDKs don't know the symbol at all. The `_np` variant has been available since macOS 10.15 and is still present on 26, so use it unconditionally.

Verified: `swift build -c release` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EKZt6tbe4WEBsdPWYZQr6g