### PR TITLE
Run the release workflow on macos-26

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: macos-15
+    runs-on: macos-26
     timeout-minutes: 60
 
     steps:
@@ -31,8 +31,10 @@ jobs:
             echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
           fi
 
-      # O macos-15 ja traz Xcode 16.x (Swift 6) por omissao. Se um dia precisares
-      # de fixar a versao, descomenta o passo maxim-lobanov/setup-xcode.
+      # O macos-26 traz Xcode 26.x (Swift 6.3) por omissao — o mesmo toolchain do
+      # desenvolvimento local; com o macos-15 (Swift 6.1) o strict concurrency
+      # rejeita codigo que o 6.3 aceita. Se um dia precisares de fixar a versao,
+      # descomenta o passo maxim-lobanov/setup-xcode.
       # - uses: maxim-lobanov/setup-xcode@v1
       #   with:
       #     xcode-version: '16.4'


### PR DESCRIPTION
Third and hopefully last CI failure for v1.0.0: the `macos-15` image ships **Swift 6.1**, whose strict concurrency rejects code the local **Swift 6.3 / Xcode 26** toolchain accepts (`sending 'request' risks causing data races` in `AppNotifier.swift`, `TerminalSession.swift`). Rather than chasing diagnostics across compiler versions, run CI on the same toolchain the app is developed with: `macos-26` is GA and is what `macos-latest` points to.

After merging, moving the `v1.0.0` tag to the new `main` re-triggers the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EKZt6tbe4WEBsdPWYZQr6g