### PR TITLE
Bind release job to the release environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,10 @@ permissions:
 jobs:
   release:
     runs-on: macos-26
+    # Os segredos de assinatura vivem no ambiente release, por isso o job tem de
+    # o declarar. Sem isto os secrets.* ficam vazios e a importacao do
+    # certificado falha.
+    environment: release
     timeout-minutes: 60
 
     steps:


### PR DESCRIPTION
The release workflow fails at the certificate import step with `SecKeychainItemImport: One or more parameters passed to a function were not valid`. The real cause is that all five signing secrets live in the `release` environment, and there are no repo- or org-level secrets. The job never declared that environment, so every `secrets.*` reference resolved to an empty string and `security import` got a 0-byte p12.

Two follow-ups this does not cover, since both are repo settings rather than code:

- The `release` environment requires reviewer approval, so releases will now pause waiting for a click. That looks intentional.
- Its deployment branch policy only allows the tag pattern `v*`. The failing run was a `workflow_dispatch` from `main`, which that policy rejects. So manual dispatch stays broken until `main` is added as a branch policy, or we accept tag-only releases and drop the dispatch trigger.