### PR TITLE
Translate release docs and scripts to English

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 name: Release
 
-# Publica um DMG assinado e notarizado sempre que fizeres push de uma tag v*.
+# Publishes a signed and notarized DMG whenever you push a v* tag.
 #   git tag v1.2.0 && git push origin v1.2.0
 on:
   push:
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Versao a construir (ex.: 1.2.0)'
+        description: 'Version to build (e.g.: 1.2.0)'
         required: true
 
 permissions:
@@ -17,16 +17,16 @@ permissions:
 jobs:
   release:
     runs-on: macos-26
-    # Os segredos de assinatura vivem no ambiente release, por isso o job tem de
-    # o declarar. Sem isto os secrets.* ficam vazios e a importacao do
-    # certificado falha.
+    # The signing secrets live in the release environment, so the job has to
+    # declare it. Without this the secrets.* are empty and the certificate
+    # import fails.
     environment: release
     timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Determinar versao
+      - name: Work out the version
         id: v
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
@@ -35,17 +35,17 @@ jobs:
             echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
           fi
 
-      # O macos-26 traz Xcode 26.x (Swift 6.3) por omissao — o mesmo toolchain do
-      # desenvolvimento local; com o macos-15 (Swift 6.1) o strict concurrency
-      # rejeita codigo que o 6.3 aceita. Se um dia precisares de fixar a versao,
-      # descomenta o passo maxim-lobanov/setup-xcode.
+      # macos-26 ships Xcode 26.x (Swift 6.3) by default - the same toolchain as
+      # local development; on macos-15 (Swift 6.1) strict concurrency rejects
+      # code that 6.3 accepts. If you ever need to pin the version, uncomment
+      # the maxim-lobanov/setup-xcode step.
       # - uses: maxim-lobanov/setup-xcode@v1
       #   with:
       #     xcode-version: '16.4'
       - name: Toolchain
         run: swift --version && xcodebuild -version
 
-      - name: Importar certificado Developer ID
+      - name: Import the Developer ID certificate
         env:
           CERT_P12: ${{ secrets.MACOS_CERTIFICATE_P12 }}
           CERT_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
@@ -61,7 +61,8 @@ jobs:
           security import "$RUNNER_TEMP/cert.p12" \
             -k "$KEYCHAIN" -P "$CERT_PASSWORD" \
             -T /usr/bin/codesign -T /usr/bin/security
-          # Sem isto o codesign para a pedir a password numa UI que nao existe.
+          # Without this codesign stops to ask for the password in a UI that
+          # does not exist.
           security set-key-partition-list -S apple-tool:,apple:,codesign: \
             -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN" >/dev/null
           security list-keychain -d user -s "$KEYCHAIN" login.keychain-db
@@ -69,7 +70,7 @@ jobs:
           rm -f "$RUNNER_TEMP/cert.p12"
           security find-identity -v -p codesigning "$KEYCHAIN"
 
-      - name: Escrever chave da API do App Store Connect
+      - name: Write the App Store Connect API key
         env:
           AC_API_KEY_P8: ${{ secrets.AC_API_KEY_P8 }}
         run: |
@@ -77,7 +78,7 @@ jobs:
           echo "$AC_API_KEY_P8" | base64 --decode \
             > "$RUNNER_TEMP/private_keys/AuthKey.p8"
 
-      - name: Build, assinar, notarizar, empacotar
+      - name: Build, sign, notarize, package
         env:
           AC_API_KEY_PATH: ${{ runner.temp }}/private_keys/AuthKey.p8
           AC_API_KEY_ID: ${{ secrets.AC_API_KEY_ID }}
@@ -86,15 +87,15 @@ jobs:
           BUILD_NUMBER: ${{ github.run_number }}
         run: ./Scripts/release.sh "${{ steps.v.outputs.version }}"
 
-      - name: Limpar segredos do runner
+      - name: Clean the secrets off the runner
         if: always()
         run: rm -rf "$RUNNER_TEMP/private_keys" "$RUNNER_TEMP/build.keychain-db"
 
-      - name: Publicar a GitHub Release
+      - name: Publish the GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           name: Teya Code Station ${{ steps.v.outputs.version }}
-          draft: true          # revê antes de tornar publica
+          draft: true          # review it before making it public
           generate_release_notes: true
           files: |
             build/TeyaCodeStation-${{ steps.v.outputs.version }}.dmg

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,46 +1,46 @@
-# Publicar o Teya Code Station
+# Publishing Teya Code Station
 
-Distribuição fora da App Store: **Developer ID Application + hardened runtime + notarização + DMG**. Sem isto, quem faz download vê *"não pode ser aberto porque a Apple não conseguiu verificar se contém software malicioso"*.
+Distribution outside the App Store: **Developer ID Application + hardened runtime + notarization + DMG**. Without this, anyone who downloads it sees *"cannot be opened because Apple cannot check it for malicious software"*.
 
 Team ID: `QZG8V8U2Y6` · Bundle ID: `com.teya.code-station`
 
-## 0. O que já está feito
+## 0. What is already done
 
-- [x] Certificado **Developer ID Application — Teya Services Limited**, válido até 2031-09-01
-- [x] Certificado descarregado e instalado na Keychain
-- [x] Chave de API do App Store Connect no sítio certo (`~/private_keys/AuthKey_2VM7JH4JUA.p8`)
-- [x] Primeira release manual (1.0.0, notarizada e validada com quarentena a 2026-08-31)
-- [ ] Workflow de CI
+- [x] **Developer ID Application - Teya Services Limited** certificate, valid until 2031-09-01
+- [x] Certificate downloaded and installed in the Keychain
+- [x] App Store Connect API key in the right place (`~/private_keys/AuthKey_2VM7JH4JUA.p8`)
+- [x] First manual release (1.0.0, notarized and checked with quarantine on 2026-08-31)
+- [ ] CI workflow
 
-## 1. Instalar o certificado
+## 1. Install the certificate
 
-Na página do certificado, clica **Download**, depois duplo-clique no `.cer`. Confirma:
+On the certificate page, click **Download**, then double-click the `.cer`. Check it:
 
 ```bash
 security find-identity -v -p codesigning
 ```
 
-Tem de aparecer:
+This has to show up:
 
 ```
 1) ABC123… "Developer ID Application: Teya Services Limited (QZG8V8U2Y6)"
 ```
 
-Se aparecer o certificado mas o `codesign` falhar com *"no identity found"*, é porque a chave privada não está nesta máquina. A chave privada só existe no Mac onde geraste o `.certSigningRequest`. Nesse caso, exporta de lá o par certificado+chave como `.p12`.
+If the certificate shows up but `codesign` fails with *"no identity found"*, the private key is not on this machine. The private key only exists on the Mac where you generated the `.certSigningRequest`. In that case, export the certificate and key pair from there as a `.p12`.
 
-## 2. Chave de API do App Store Connect
+## 2. App Store Connect API key
 
-Guarda o `.p8` fora do repositório (ex.: `~/private_keys/AuthKey_XXXXXXXXXX.p8`). Precisas de três coisas: o ficheiro, o **Key ID** e o **Issuer ID** (App Store Connect → Users and Access → Integrations → Keys).
+Keep the `.p8` outside the repository (for example `~/private_keys/AuthKey_XXXXXXXXXX.p8`). You need three things: the file, the **Key ID** and the **Issuer ID** (App Store Connect → Users and Access → Integrations → Keys).
 
-## 3. Ficheiros a adicionar ao repo
+## 3. Files to add to the repo
 
 ```
-Resources/CodeStation.entitlements   # hardened runtime, mínimo
-Scripts/release.sh                   # build → assinar → notarizar → DMG
-.github/workflows/release.yml        # o mesmo, em CI, por tag
+Resources/CodeStation.entitlements   # hardened runtime, minimal
+Scripts/release.sh                   # build → sign → notarize → DMG
+.github/workflows/release.yml        # the same, in CI, per tag
 ```
 
-## 4. Release manual (faz esta primeiro)
+## 4. Manual release (do this one first)
 
 ```bash
 export AC_API_KEY_PATH=~/private_keys/AuthKey_XXXXXXXXXX.p8
@@ -50,63 +50,63 @@ export AC_API_ISSUER_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 ./Scripts/release.sh 1.0.0
 ```
 
-O script faz, por esta ordem:
+The script does this, in order:
 
 1. `./build-app.sh release`
-2. escreve a versão no `Info.plist`
-3. reassina tudo com Developer ID, `--options runtime --timestamp` (substitui a assinatura ad-hoc do `build-app.sh`)
-4. `notarytool submit --wait` da `.app` → `stapler staple`
-5. cria o DMG com atalho para `/Applications`, assina, notariza e faz staple
-6. valida com `spctl` e escreve o SHA-256
+2. writes the version into `Info.plist`
+3. re-signs everything with Developer ID, `--options runtime --timestamp` (replaces the ad-hoc signature left by `build-app.sh`)
+4. `notarytool submit --wait` on the `.app` → `stapler staple`
+5. builds the DMG with a shortcut to `/Applications`, signs it, notarizes it and staples it
+6. checks it with `spctl` and writes the SHA-256
 
-Demora tipicamente 5–15 minutos, quase tudo à espera da Apple.
+It usually takes 5-15 minutes, almost all of it waiting on Apple.
 
-### O teste que interessa
+### The test that matters
 
-**Não testes no Mac onde compilaste** — não tem quarentena. Manda o DMG para outra máquina (ou simula):
+**Do not test on the Mac you built on** - it has no quarantine. Send the DMG to another machine (or fake the flag):
 
 ```bash
 xattr -w com.apple.quarantine "0081;00000000;Safari;" TeyaCodeStation-1.0.0.dmg
 ```
 
-Depois abre normalmente. Tem de abrir sem avisos e sem botão direito → Abrir.
+Then open it as usual. It has to open with no warnings and without right-click → Open.
 
-## 5. Automatizar
+## 5. Automate it
 
-Secrets a criar em Settings → Secrets and variables → Actions:
+Secrets to create in Settings → Secrets and variables → Actions:
 
-| Secret | Como obter |
+| Secret | How to get it |
 |---|---|
-| `MACOS_CERTIFICATE_P12` | Keychain Access → certificado + chave → Export `.p12` → `base64 -i cert.p12 \| pbcopy` |
-| `MACOS_CERTIFICATE_PASSWORD` | a password que puseste ao exportar o `.p12` |
+| `MACOS_CERTIFICATE_P12` | Keychain Access → certificate + key → Export `.p12` → `base64 -i cert.p12 \| pbcopy` |
+| `MACOS_CERTIFICATE_PASSWORD` | the password you set when exporting the `.p12` |
 | `AC_API_KEY_P8` | `base64 -i AuthKey_XXXX.p8 \| pbcopy` |
-| `AC_API_KEY_ID` | Key ID (10 caracteres) |
+| `AC_API_KEY_ID` | Key ID (10 characters) |
 | `AC_API_ISSUER_ID` | Issuer ID (UUID) |
 
-Depois:
+Then:
 
 ```bash
 git tag v1.0.0 && git push origin v1.0.0
 ```
 
-O workflow cria uma **draft release** com o DMG e o `.sha256`. Revês e publicas.
+The workflow creates a **draft release** with the DMG and the `.sha256`. You review it and publish it.
 
-## 6. Actualizar a página
+## 6. Update the page
 
-https://teya-engineering.github.io/code-station/ diz hoje para clonar e correr `./build-app.sh`. Depois da primeira release, o caminho principal passa a ser:
+https://teya-engineering.github.io/code-station/ currently tells people to clone the repo and run `./build-app.sh`. After the first release, the main path becomes:
 
-- botão de download apontando para `https://github.com/teya-engineering/code-station/releases/latest`
-- requisitos: macOS 14+
-- build a partir do código passa a ser a secção "para contribuidores"
+- a download button pointing at `https://github.com/teya-engineering/code-station/releases/latest`
+- requirements: macOS 14+
+- building from source moves into a "for contributors" section
 
-Nota: o `build-app.sh` injecta `site-defaults.json` no bundle. Decide se a build pública leva defaults ou vai sem configuração — o que for para dentro do `.app` fica assinado e é distribuído a toda a gente.
+Note: `build-app.sh` injects `site-defaults.json` into the bundle. Decide whether the public build ships with defaults or with no configuration at all - whatever goes inside the `.app` is signed and handed to everyone.
 
-## Problemas comuns
+## Common problems
 
-| Sintoma | Causa |
+| Symptom | Cause |
 |---|---|
-| `notarytool` devolve `Invalid` | corre `xcrun notarytool log <id> --key … --key-id … --issuer …`; quase sempre é um binário sem hardened runtime ou sem secure timestamp |
-| App crasha só depois de assinada | falta um entitlement — vê os comentários em `CodeStation.entitlements` e acrescenta um de cada vez |
-| `The signature does not include a secure timestamp` | faltou `--timestamp`, ou a máquina não tinha rede ao assinar |
-| `spctl` diz `rejected` mesmo notarizado | esqueceste o `stapler staple`, ou testaste um ficheiro sem quarentena |
-| Erro de keychain em CI | falta o `security set-key-partition-list` |
+| `notarytool` returns `Invalid` | run `xcrun notarytool log <id> --key … --key-id … --issuer …`; it is nearly always a binary without hardened runtime or without a secure timestamp |
+| App only crashes once it is signed | a missing entitlement - read the comments in `CodeStation.entitlements` and add them one at a time |
+| `The signature does not include a secure timestamp` | `--timestamp` was missing, or the machine had no network while signing |
+| `spctl` says `rejected` even though it is notarized | you forgot `stapler staple`, or you tested a file with no quarantine |
+| Keychain error in CI | `security set-key-partition-list` is missing |

--- a/Resources/CodeStation.entitlements
+++ b/Resources/CodeStation.entitlements
@@ -3,29 +3,30 @@
 <plist version="1.0">
 <dict>
     <!--
-      Deliberadamente minimo. O hardened runtime e' obrigatorio para notarizar.
-      A app nao esta em sandbox, por isso rede, ficheiros e spawn de processos
-      (codex / claude, git, shell) funcionam sem entitlements nenhuns.
+      Deliberately minimal. The hardened runtime is required for notarization.
+      The app is not sandboxed, so network, files and spawning processes
+      (codex / claude, git, shell) all work with no entitlements at all.
 
-      Se depois de assinar a app rebentar ao arrancar ou ao lancar um agente,
-      acrescenta SO a que for precisa, uma de cada vez:
+      If the app starts crashing on launch, or when starting an agent, only
+      after it is signed, add ONLY the one you need, one at a time:
 
       <key>com.apple.security.cs.allow-jit</key><true/>
-          -> so se a propria app compilar codigo em runtime (nao e' o caso
-             dos agentes: esses sao processos filhos com assinatura propria).
+          -> only if the app itself compiles code at runtime (not the case
+             for the agents: those are child processes with their own
+             signature).
 
       <key>com.apple.security.cs.disable-library-validation</key><true/>
-          -> so se a app carregar dylibs/plugins de terceiros nao assinados
-             pela mesma Team ID.
+          -> only if the app loads third-party dylibs or plugins that are not
+             signed by the same Team ID.
 
       <key>com.apple.security.cs.allow-dyld-environment-variables</key><true/>
-          -> so se definires DYLD_* para os processos filhos.
+          -> only if you set DYLD_* for the child processes.
 
       <key>com.apple.security.automation.apple-events</key><true/>
-          -> so se a app enviar Apple Events (ex.: controlar o Terminal.app).
+          -> only if the app sends Apple Events (e.g. driving Terminal.app).
 
-      Cada entitlement destes enfraquece o hardened runtime. Nao os metas
-      "por seguranca" - mete-os por sintoma.
+      Each of these weakens the hardened runtime. Do not add them "to be
+      safe" - add them in response to a symptom.
     -->
 </dict>
 </plist>

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
-# Assina, notariza e empacota o Teya Code Station para distribuicao fora da App Store.
+# Signs, notarizes and packages Teya Code Station for distribution outside the App Store.
 #
-# Requisitos no Mac (ou no runner):
-#   - Certificado "Developer ID Application: Teya Services Limited (QZG8V8U2Y6)" na keychain
-#   - Chave de API do App Store Connect (.p8) com role Developer ou superior
+# Needed on the Mac (or on the runner):
+#   - "Developer ID Application: Teya Services Limited (QZG8V8U2Y6)" certificate in the keychain
+#   - App Store Connect API key (.p8) with the Developer role or higher
 #   - Xcode command line tools (codesign, notarytool, stapler, hdiutil)
 #
-# Uso:
+# Usage:
 #   export AC_API_KEY_PATH=~/private_keys/AuthKey_XXXXXXXXXX.p8
 #   export AC_API_KEY_ID=XXXXXXXXXX
 #   export AC_API_ISSUER_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
@@ -16,7 +16,7 @@ set -euo pipefail
 
 VERSION="${1:-}"
 if [ -z "$VERSION" ]; then
-    echo "uso: $0 <versao>   (ex.: $0 1.2.0)" >&2
+    echo "usage: $0 <version>   (e.g.: $0 1.2.0)" >&2
     exit 1
 fi
 BUILD_NUMBER="${BUILD_NUMBER:-$(date +%Y%m%d%H%M)}"
@@ -28,11 +28,11 @@ TEAM_ID="${TEAM_ID:-QZG8V8U2Y6}"
 IDENTITY="${SIGN_IDENTITY:-Developer ID Application: Teya Services Limited ($TEAM_ID)}"
 ENTITLEMENTS="Resources/CodeStation.entitlements"
 
-: "${AC_API_KEY_PATH:?falta AC_API_KEY_PATH (caminho para o .p8)}"
-: "${AC_API_KEY_ID:?falta AC_API_KEY_ID}"
-: "${AC_API_ISSUER_ID:?falta AC_API_ISSUER_ID}"
+: "${AC_API_KEY_PATH:?missing AC_API_KEY_PATH (path to the .p8)}"
+: "${AC_API_KEY_ID:?missing AC_API_KEY_ID}"
+: "${AC_API_ISSUER_ID:?missing AC_API_ISSUER_ID}"
 
-# As credenciais vao DEPOIS do subcomando: "notarytool submit <file> --key ..."
+# The credentials go AFTER the subcommand: "notarytool submit <file> --key ..."
 NOTARY_ARGS=(--key "$AC_API_KEY_PATH"
              --key-id "$AC_API_KEY_ID"
              --issuer "$AC_API_ISSUER_ID")
@@ -40,16 +40,16 @@ NOTARY_ARGS=(--key "$AC_API_KEY_PATH"
 step() { printf '\n\033[1m==> %s\033[0m\n' "$1"; }
 
 # ---------------------------------------------------------------- 1. build
-step "A construir $APP_NAME $VERSION ($BUILD_NUMBER)"
+step "Building $APP_NAME $VERSION ($BUILD_NUMBER)"
 ./build-app.sh release
 
 /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $VERSION" "$APP/Contents/Info.plist"
 /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $BUILD_NUMBER"       "$APP/Contents/Info.plist"
 
-# ---------------------------------------------------------------- 2. assinar
-# O build-app.sh deixa uma assinatura ad-hoc. Substitui-se por Developer ID,
-# de dentro para fora: primeiro tudo o que esta encaixado, depois a app.
-step "A assinar com: $IDENTITY"
+# ---------------------------------------------------------------- 2. sign
+# build-app.sh leaves an ad-hoc signature. It gets replaced with Developer ID,
+# from the inside out: everything nested first, then the app itself.
+step "Signing with: $IDENTITY"
 
 sign() {
     codesign --force \
@@ -60,17 +60,17 @@ sign() {
              "$@"
 }
 
-# Nested bundles, frameworks e binarios soltos primeiro (nunca uses --deep:
-# a Apple desaconselha-o e nao aplica entitlements aos nested correctamente).
-# Bundles so de recursos (ex.: MenuBarApp_MenuBarApp.bundle, sem Mach-O) nao
-# sao assinaveis; ficam selados pela assinatura da app.
+# Nested bundles, frameworks and loose binaries first (never use --deep:
+# Apple advises against it and it does not apply entitlements to the nested
+# code correctly). Resource-only bundles (e.g. MenuBarApp_MenuBarApp.bundle,
+# with no Mach-O) cannot be signed; the app signature seals them instead.
 has_macho() {
     [ -n "$(find "$1" -type f -exec sh -c 'file -b "$0" 2>/dev/null | grep -q Mach-O' {} \; -print -quit)" ]
 }
 
 while IFS= read -r -d '' nested; do
     if ! has_macho "$nested"; then
-        echo "    sem codigo, salto: ${nested#$APP/}"
+        echo "    no code, skipping: ${nested#$APP/}"
         continue
     fi
     echo "    nested: ${nested#$APP/}"
@@ -81,12 +81,12 @@ done < <(find "$APP/Contents" \
 
 sign "$APP"
 
-step "A verificar a assinatura"
+step "Checking the signature"
 codesign --verify --strict --deep --verbose=2 "$APP"
 codesign --display --verbose=4 "$APP" 2>&1 | grep -E 'Authority|TeamIdentifier|flags|Timestamp'
 
-# ---------------------------------------------------------------- 3. notarizar a app
-step "A notarizar a app (pode demorar 1-15 min)"
+# ---------------------------------------------------------------- 3. notarize the app
+step "Notarizing the app (can take 1-15 min)"
 ZIP="build/$APP_NAME-notarize.zip"
 rm -f "$ZIP"
 /usr/bin/ditto -c -k --keepParent "$APP" "$ZIP"
@@ -95,7 +95,7 @@ xcrun stapler staple "$APP"
 rm -f "$ZIP"
 
 # ---------------------------------------------------------------- 4. DMG
-step "A criar o DMG"
+step "Building the DMG"
 STAGE="$(mktemp -d)"
 cp -R "$APP" "$STAGE/"
 ln -s /Applications "$STAGE/Applications"
@@ -106,17 +106,17 @@ hdiutil create -volname "$APP_NAME" \
                "$DMG"
 rm -rf "$STAGE"
 
-step "A assinar e notarizar o DMG"
+step "Signing and notarizing the DMG"
 codesign --force --sign "$IDENTITY" --timestamp "$DMG"
 xcrun notarytool submit "$DMG" --wait "${NOTARY_ARGS[@]}"
 xcrun stapler staple "$DMG"
 
-# ---------------------------------------------------------------- 5. validar
-step "Validacao final (e' isto que o Gatekeeper vai ver)"
+# ---------------------------------------------------------------- 5. validate
+step "Final check (this is what Gatekeeper will see)"
 xcrun stapler validate "$DMG"
 spctl --assess --type open --context context:primary-signature -vv "$DMG"
 spctl --assess --type execute -vv "$APP"
 
 shasum -a 256 "$DMG" | tee "$DMG.sha256"
 
-printf '\n\033[1;32mPronto:\033[0m %s\n' "$DMG"
+printf '\n\033[1;32mDone:\033[0m %s\n' "$DMG"


### PR DESCRIPTION
The release tooling was the only Portuguese left in the repo. This translates all of it, so the whole codebase reads in one language: `RELEASE.md`, `Scripts/release.sh`, `Resources/CodeStation.entitlements` and `.github/workflows/release.yml`.

Text only. No shell command, flag, or YAML key changed - the only non-comment edits are the workflow's step `name:` values (which show up in the Actions UI) and the `version` input description, plus the script's `echo`/`step` output.

One thing left alone on purpose: section 5 of `RELEASE.md` still says to create the secrets under Settings -> Secrets and variables -> Actions, but they actually live in the `release` environment. That is a content fix, not a translation, so it is not in here.