### PR TITLE
Pass an explicit tag_name to action-gh-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,6 +94,9 @@ jobs:
       - name: Publish the GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          # Explicit so workflow_dispatch runs work too - without it the action
+          # falls back to github.ref, which is a branch on dispatch.
+          tag_name: v${{ steps.v.outputs.version }}
           name: Teya Code Station ${{ steps.v.outputs.version }}
           draft: true          # review it before making it public
           generate_release_notes: true


### PR DESCRIPTION
The three `workflow_dispatch` runs failed at the publish step with `Missing tag_name parameter`: on dispatch, `github.ref` is a branch, and `action-gh-release` has no tag to attach the release to. Passing `tag_name: v${{ steps.v.outputs.version }}` explicitly fixes dispatch runs; tag pushes behave the same as before.

Not needed for the pending v1.0.0 tag run (33415305991) — that one publishes fine once its deployment is approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EKZt6tbe4WEBsdPWYZQr6g