### PR TITLE
Fix manual release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,6 +94,8 @@ jobs:
       - name: Publish the GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: v${{ steps.v.outputs.version }}
+          target_commitish: ${{ github.sha }}
           name: Teya Code Station ${{ steps.v.outputs.version }}
           draft: true          # review it before making it public
           generate_release_notes: true


### PR DESCRIPTION
Manual release runs use a branch ref, so the release action cannot infer which tag to create. Supply the normalized version as the tag name and target the workflow commit so manual and tag-triggered releases behave consistently.