### PR TITLE
Add app update notifications

### DIFF
--- a/Sources/MenuBarApp/AppPaths.swift
+++ b/Sources/MenuBarApp/AppPaths.swift
@@ -337,6 +337,43 @@ enum Preferences {
         store.set(date, forKey: "skillsLastRefresh")
     }
 
+    static func appUpdateLastCheck(in store: UserDefaults = .standard) -> Date? {
+        store.object(forKey: "appUpdateLastCheck") as? Date
+    }
+
+    static func setAppUpdateLastCheck(_ date: Date?, in store: UserDefaults = .standard) {
+        store.set(date, forKey: "appUpdateLastCheck")
+    }
+
+    static func cachedAppUpdateRelease(
+        in store: UserDefaults = .standard
+    ) -> AppUpdateRelease? {
+        guard let data = store.data(forKey: "cachedAppUpdateRelease") else { return nil }
+        return try? JSONDecoder().decode(AppUpdateRelease.self, from: data)
+    }
+
+    static func setCachedAppUpdateRelease(
+        _ release: AppUpdateRelease?,
+        in store: UserDefaults = .standard
+    ) {
+        guard let release, let data = try? JSONEncoder().encode(release) else {
+            store.removeObject(forKey: "cachedAppUpdateRelease")
+            return
+        }
+        store.set(data, forKey: "cachedAppUpdateRelease")
+    }
+
+    static func dismissedAppUpdateVersion(in store: UserDefaults = .standard) -> String? {
+        store.string(forKey: "dismissedAppUpdateVersion")
+    }
+
+    static func setDismissedAppUpdateVersion(
+        _ version: String?,
+        in store: UserDefaults = .standard
+    ) {
+        store.set(version, forKey: "dismissedAppUpdateVersion")
+    }
+
     // The skills a diagnosis is told to use. The choice belongs to the person rather than
     // to any one problem, so the next Troubleshoot opens with the last one already made.
     static func troubleshootSkills(in store: UserDefaults = .standard) -> Set<String> {

--- a/Sources/MenuBarApp/AppUpdateChecker.swift
+++ b/Sources/MenuBarApp/AppUpdateChecker.swift
@@ -1,0 +1,164 @@
+import AppKit
+import Foundation
+import Observation
+
+struct AppUpdateRelease: Codable, Equatable, Sendable {
+    let version: String
+    let pageURL: URL
+}
+
+struct AppVersion: Comparable, Equatable, Sendable {
+    let display: String
+    private let components: [Int]
+
+    init?(_ value: String) {
+        var version = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        if version.first == "v" || version.first == "V" {
+            version.removeFirst()
+        }
+        let pieces = version.split(separator: ".", omittingEmptySubsequences: false)
+        guard !pieces.isEmpty else { return nil }
+
+        let components = pieces.compactMap { piece -> Int? in
+            guard !piece.isEmpty, piece.allSatisfy(\.isNumber) else { return nil }
+            return Int(piece)
+        }
+        guard components.count == pieces.count else { return nil }
+
+        display = version
+        self.components = components
+    }
+
+    static func == (left: Self, right: Self) -> Bool {
+        compare(left.components, right.components) == 0
+    }
+
+    static func < (left: Self, right: Self) -> Bool {
+        compare(left.components, right.components) < 0
+    }
+
+    private static func compare(_ left: [Int], _ right: [Int]) -> Int {
+        for index in 0..<max(left.count, right.count) {
+            let leftPart = index < left.count ? left[index] : 0
+            let rightPart = index < right.count ? right[index] : 0
+            if leftPart != rightPart { return leftPart < rightPart ? -1 : 1 }
+        }
+        return 0
+    }
+}
+
+@MainActor
+@Observable
+final class AppUpdateChecker {
+    nonisolated static let checkInterval: TimeInterval = 5 * 86_400
+
+    private(set) var availableRelease: AppUpdateRelease?
+    private(set) var isChecking = false
+    private(set) var dismissedVersion: String?
+
+    @ObservationIgnored private let installedVersion: AppVersion?
+    @ObservationIgnored private let preferences: UserDefaults
+    @ObservationIgnored private let session: URLSession
+    @ObservationIgnored private let now: () -> Date
+    @ObservationIgnored private let releaseEndpoint: URL
+
+    var announcedRelease: AppUpdateRelease? {
+        guard let availableRelease,
+              availableRelease.version != dismissedVersion else { return nil }
+        return availableRelease
+    }
+
+    init(
+        installedVersion: String? = Bundle.main.object(
+            forInfoDictionaryKey: "CFBundleShortVersionString") as? String,
+        preferences: UserDefaults = .standard,
+        session: URLSession = .shared,
+        now: @escaping () -> Date = Date.init,
+        releaseEndpoint: URL = URL(
+            string: "https://api.github.com/repos/teya-engineering/code-station/releases/latest")!
+    ) {
+        self.installedVersion = installedVersion.flatMap(AppVersion.init)
+        self.preferences = preferences
+        self.session = session
+        self.now = now
+        self.releaseEndpoint = releaseEndpoint
+        dismissedVersion = Preferences.dismissedAppUpdateVersion(in: preferences)
+        availableRelease = Self.available(
+            Preferences.cachedAppUpdateRelease(in: preferences),
+            to: self.installedVersion)
+    }
+
+    func checkIfNeeded() async {
+        guard installedVersion != nil, !isChecking else { return }
+        let checkedAt = now()
+        guard Self.shouldCheck(
+            lastCheck: Preferences.appUpdateLastCheck(in: preferences),
+            now: checkedAt) else { return }
+
+        Preferences.setAppUpdateLastCheck(checkedAt, in: preferences)
+        isChecking = true
+        defer { isChecking = false }
+
+        do {
+            var request = URLRequest(url: releaseEndpoint)
+            request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+            request.setValue("2026-03-10", forHTTPHeaderField: "X-GitHub-Api-Version")
+            request.setValue("Teya-Code-Station", forHTTPHeaderField: "User-Agent")
+
+            let (data, response) = try await session.data(for: request)
+            guard let response = response as? HTTPURLResponse,
+                  response.statusCode == 200,
+                  let release = Self.decodeRelease(data) else { return }
+
+            Preferences.setCachedAppUpdateRelease(release, in: preferences)
+            availableRelease = Self.available(release, to: installedVersion)
+        } catch {
+            // Automatic update checks must not interrupt work when GitHub is unavailable.
+        }
+    }
+
+    func dismissAnnouncement() {
+        guard let version = announcedRelease?.version else { return }
+        dismissedVersion = version
+        Preferences.setDismissedAppUpdateVersion(version, in: preferences)
+    }
+
+    func openReleasePage() {
+        guard let availableRelease else { return }
+        dismissAnnouncement()
+        NSWorkspace.shared.open(availableRelease.pageURL)
+    }
+
+    nonisolated static func shouldCheck(lastCheck: Date?, now: Date) -> Bool {
+        guard let lastCheck else { return true }
+        let age = now.timeIntervalSince(lastCheck)
+        return age < 0 || age >= checkInterval
+    }
+
+    nonisolated static func decodeRelease(_ data: Data) -> AppUpdateRelease? {
+        struct GitHubRelease: Decodable {
+            let tagName: String
+            let pageURL: URL
+
+            enum CodingKeys: String, CodingKey {
+                case tagName = "tag_name"
+                case pageURL = "html_url"
+            }
+        }
+
+        guard let remote = try? JSONDecoder().decode(GitHubRelease.self, from: data),
+              let version = AppVersion(remote.tagName),
+              remote.pageURL.scheme == "https",
+              remote.pageURL.host == "github.com" else { return nil }
+        return AppUpdateRelease(version: version.display, pageURL: remote.pageURL)
+    }
+
+    private static func available(_ release: AppUpdateRelease?,
+                                  to installedVersion: AppVersion?) -> AppUpdateRelease? {
+        guard let release,
+              let latestVersion = AppVersion(release.version),
+              let installedVersion,
+              latestVersion > installedVersion else { return nil }
+        return release
+    }
+}

--- a/Sources/MenuBarApp/MenuBarApp.swift
+++ b/Sources/MenuBarApp/MenuBarApp.swift
@@ -65,6 +65,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private let dispatchRunner = DispatchRunner()
     private let dispatchAuth = DispatchAuthStore()
     private let shortcuts = ShortcutStore()
+    private let appUpdates = AppUpdateChecker()
     private var window: NSWindow?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
@@ -139,7 +140,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     .environment(dispatch)
                     .environment(dispatchRunner)
                     .environment(dispatchAuth)
-                    .environment(shortcuts))
+                    .environment(shortcuts)
+                    .environment(appUpdates))
             // Let the window own its size instead of shrinking to the view's ideal size.
             hosting.sizingOptions = []
             let win = NSWindow(

--- a/Sources/MenuBarApp/Projects/AppSidebar.swift
+++ b/Sources/MenuBarApp/Projects/AppSidebar.swift
@@ -13,6 +13,7 @@ struct AppSidebar: View {
     @Environment(SessionRunner.self) private var runner
     @Environment(ShortcutStore.self) private var shortcuts
     @Environment(DialogPresenter.self) private var dialogs
+    @Environment(AppUpdateChecker.self) private var appUpdates
     @Environment(AppSettings.self) private var appSettings
     @Environment(WorkingTreeWatch.self) private var workingTrees
     @Environment(OrphanedWorktreeMonitor.self) private var orphanedWorktrees
@@ -1067,7 +1068,8 @@ struct AppSidebar: View {
                     .appMenu(edge: .top, matchWidth: true, addMenu)
                     .accessibilityLabel("Add a project, workspace, or task")
 
-                SettingsButton(showsUpdate: skills.updateCount > 0)
+                SettingsButton(showsUpdate: skills.updateCount > 0
+                               || appUpdates.availableRelease != nil)
                     .toolsMenu(tools, skills: skills, edge: .top)
             }
 

--- a/Sources/MenuBarApp/RootView.swift
+++ b/Sources/MenuBarApp/RootView.swift
@@ -14,6 +14,7 @@ struct RootView: View {
     @Environment(SessionRunner.self) private var runner
     @Environment(MobileAccessController.self) private var mobileAccess
     @Environment(OrphanedWorktreeMonitor.self) private var orphanedWorktrees
+    @Environment(AppUpdateChecker.self) private var appUpdates
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var skills = SkillsManager()
     @State private var commandPalette = GlobalCommandPaletteController()
@@ -36,12 +37,19 @@ struct RootView: View {
                 detail
             }
             ScheduledTaskRunner()
-            if let attention, attention != dismissedAttention {
-                AttentionBanner(title: attention.title,
-                                message: attention.message,
-                                onDismiss: { dismissedAttention = attention })
-                    .padding(.top, 12)
+            VStack(spacing: 8) {
+                if let attention, attention != dismissedAttention {
+                    AttentionBanner(title: attention.title,
+                                    message: attention.message,
+                                    onDismiss: { dismissedAttention = attention })
+                }
+                if let release = appUpdates.announcedRelease {
+                    AppUpdateBanner(release: release,
+                                    onViewRelease: appUpdates.openReleasePage,
+                                    onDismiss: appUpdates.dismissAnnouncement)
+                }
             }
+            .padding(.top, 12)
             if commandPalette.isPresented {
                 commandPaletteLayer
                     .transition(.opacity)
@@ -82,6 +90,7 @@ struct RootView: View {
             store.applicationDidBecomeActive()
         }
         .task { await resumePendingSessionRemovals() }
+        .task { await appUpdates.checkIfNeeded() }
         .task(id: skillsRefreshRule) { await refreshSkillsAutomatically() }
         .task(id: sweepRule) { await deleteOldSessionsAutomatically() }
         .task(id: settings.autoPruneOrphanedWorktrees) { await monitorOrphanedWorktrees() }
@@ -411,6 +420,47 @@ private struct AttentionBanner: View {
         .padding(.vertical, 9)
         .frame(maxWidth: 720, alignment: .leading)
         .surface(Theme.card, cornerRadius: 10, border: Theme.deletion.opacity(0.45))
+        .shadow(color: Color.black.opacity(0.12), radius: 12, y: 4)
+    }
+}
+
+private struct AppUpdateBanner: View {
+    let release: AppUpdateRelease
+    let onViewRelease: () -> Void
+    let onDismiss: () -> Void
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 10) {
+            Image(systemName: "arrow.down.circle.fill")
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(Theme.accent)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Teya Code Station \(release.version) is available")
+                    .font(.system(size: 12, weight: .semibold))
+                Text("View the release notes and download the signed update from GitHub.")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            ActionButton(title: "View release", tone: .outlined, height: 28, size: 11,
+                         action: onViewRelease)
+            Button(action: onDismiss) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 9, weight: .bold))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 22, height: 22)
+                    .background(Circle().fill(Theme.field))
+                    .overlay(Circle().stroke(Theme.border))
+                    .contentShape(Circle())
+            }
+            .buttonStyle(.plain)
+            .appTooltip("Dismiss")
+            .accessibilityLabel("Dismiss update \(release.version)")
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 9)
+        .frame(maxWidth: 720, alignment: .leading)
+        .surface(Theme.card, cornerRadius: 10, border: Theme.accent.opacity(0.42))
         .shadow(color: Color.black.opacity(0.12), radius: 12, y: 4)
     }
 }

--- a/Sources/MenuBarApp/ToolsMenu.swift
+++ b/Sources/MenuBarApp/ToolsMenu.swift
@@ -34,13 +34,14 @@ private struct ToolsMenuModifier: ViewModifier {
     @Environment(DockerService.self) private var docker
     @Environment(DispatchAuthStore.self) private var dispatchAuth
     @Environment(ShortcutStore.self) private var shortcuts
+    @Environment(AppUpdateChecker.self) private var appUpdates
 
     func body(content: Content) -> some View {
         content.appMenu(edge: edge, refreshOnOpen: { await docker.refresh() }) { entries }
     }
 
     private var entries: [MenuEntry] {
-        [
+        var entries: [MenuEntry] = [
             .cards([
                 MenuCardItem(label: "MCP servers", icon: "server.rack",
                              detail: "\(configs.servers.count)",
@@ -61,10 +62,19 @@ private struct ToolsMenuModifier: ViewModifier {
                 MenuCardItem(label: "Troubleshoot", icon: "stethoscope",
                              detail: "Agent diagnosis",
                              handler: actions.openTroubleshoot)
-            ]),
-            .separator,
-            .item("Settings", detail: "⌘,", action: actions.openSettings)
+            ])
         ]
+        if let release = appUpdates.availableRelease {
+            entries.append(.separator)
+            entries.append(.item("Teya Code Station \(release.version)",
+                                 icon: "arrow.down.circle",
+                                 showsUpdate: true,
+                                 subtitle: "A new version is available",
+                                 action: appUpdates.openReleasePage))
+        }
+        entries.append(.separator)
+        entries.append(.item("Settings", detail: "⌘,", action: actions.openSettings))
+        return entries
     }
 
     private var dockerDetail: (text: String, colour: Color?) {

--- a/Tests/MenuBarAppTests/AppUpdateCheckerTests.swift
+++ b/Tests/MenuBarAppTests/AppUpdateCheckerTests.swift
@@ -1,0 +1,173 @@
+import Foundation
+import Testing
+@testable import MenuBarApp
+
+@Suite(.serialized)
+struct AppUpdateCheckerTests {
+    @Test func comparesNumericVersionComponents() throws {
+        let newer = try #require(AppVersion("1.10.0"))
+        let older = try #require(AppVersion("1.9.9"))
+
+        #expect(newer > older)
+        #expect(AppVersion("v2.0") == AppVersion("2.0.0"))
+        #expect(AppVersion("1.0-beta") == nil)
+        #expect(AppVersion("1..0") == nil)
+    }
+
+    @Test func waitsFiveDaysBetweenAutomaticChecks() {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+
+        #expect(AppUpdateChecker.shouldCheck(lastCheck: nil, now: now))
+        #expect(!AppUpdateChecker.shouldCheck(
+            lastCheck: now.addingTimeInterval(-5 * 86_400 + 1), now: now))
+        #expect(AppUpdateChecker.shouldCheck(
+            lastCheck: now.addingTimeInterval(-5 * 86_400), now: now))
+    }
+
+    @MainActor
+    @Test func findsAndCachesANewerPublishedRelease() async throws {
+        let (preferences, suite) = try preferences()
+        defer { preferences.removePersistentDomain(forName: suite) }
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        AppUpdateURLProtocol.prepare(status: 200, body: release(version: "v1.3.0"))
+        let checker = AppUpdateChecker(installedVersion: "1.2.4",
+                                       preferences: preferences,
+                                       session: stubSession(),
+                                       now: { now },
+                                       releaseEndpoint: URL(string: "https://example.test/latest")!)
+
+        await checker.checkIfNeeded()
+
+        #expect(checker.availableRelease == AppUpdateRelease(
+            version: "1.3.0",
+            pageURL: URL(string: "https://github.com/teya-engineering/code-station/releases/tag/v1.3.0")!))
+        #expect(checker.announcedRelease == checker.availableRelease)
+        #expect(Preferences.appUpdateLastCheck(in: preferences) == now)
+        #expect(Preferences.cachedAppUpdateRelease(in: preferences) == checker.availableRelease)
+        #expect(AppUpdateURLProtocol.requestCount == 1)
+        #expect(AppUpdateURLProtocol.headers["Accept"] == "application/vnd.github+json")
+        #expect(AppUpdateURLProtocol.headers["X-GitHub-Api-Version"] == "2026-03-10")
+
+        await checker.checkIfNeeded()
+
+        #expect(AppUpdateURLProtocol.requestCount == 1)
+    }
+
+    @MainActor
+    @Test func aFailedAttemptAlsoWaitsFiveDaysBeforeRetrying() async throws {
+        let (preferences, suite) = try preferences()
+        defer { preferences.removePersistentDomain(forName: suite) }
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        AppUpdateURLProtocol.prepare(status: 503, body: Data())
+        let checker = AppUpdateChecker(installedVersion: "1.0.0",
+                                       preferences: preferences,
+                                       session: stubSession(),
+                                       now: { now },
+                                       releaseEndpoint: URL(string: "https://example.test/latest")!)
+
+        await checker.checkIfNeeded()
+        await checker.checkIfNeeded()
+
+        #expect(AppUpdateURLProtocol.requestCount == 1)
+        #expect(Preferences.appUpdateLastCheck(in: preferences) == now)
+        #expect(checker.availableRelease == nil)
+    }
+
+    @MainActor
+    @Test func dismissalSurvivesRelaunchButTheUpdateRemainsAvailable() async throws {
+        let (preferences, suite) = try preferences()
+        defer { preferences.removePersistentDomain(forName: suite) }
+        let update = AppUpdateRelease(
+            version: "2.0.0",
+            pageURL: URL(string: "https://github.com/teya-engineering/code-station/releases/tag/v2.0.0")!)
+        Preferences.setCachedAppUpdateRelease(update, in: preferences)
+        let checker = AppUpdateChecker(installedVersion: "1.9.0", preferences: preferences)
+
+        checker.dismissAnnouncement()
+        let relaunched = AppUpdateChecker(installedVersion: "1.9.0", preferences: preferences)
+
+        #expect(relaunched.availableRelease == update)
+        #expect(relaunched.announcedRelease == nil)
+        #expect(Preferences.dismissedAppUpdateVersion(in: preferences) == "2.0.0")
+    }
+
+    @MainActor
+    @Test func ignoresCurrentOlderAndInvalidReleases() async throws {
+        let (preferences, suite) = try preferences()
+        defer { preferences.removePersistentDomain(forName: suite) }
+        Preferences.setCachedAppUpdateRelease(
+            AppUpdateRelease(
+                version: "1.2.0",
+                pageURL: URL(string: "https://github.com/teya-engineering/code-station/releases/tag/v1.2.0")!),
+            in: preferences)
+
+        #expect(AppUpdateChecker(installedVersion: "1.2", preferences: preferences)
+            .availableRelease == nil)
+        #expect(AppUpdateChecker(installedVersion: "1.3.0", preferences: preferences)
+            .availableRelease == nil)
+        #expect(AppUpdateChecker(installedVersion: nil, preferences: preferences)
+            .availableRelease == nil)
+        #expect(AppUpdateChecker.decodeRelease(Data("""
+        {"tag_name":"v1.4.0","html_url":"http://example.com/download"}
+        """.utf8)) == nil)
+    }
+
+    private func preferences() throws -> (UserDefaults, String) {
+        let suite = "app-update-tests-\(UUID().uuidString)"
+        return (try #require(UserDefaults(suiteName: suite)), suite)
+    }
+
+    private func stubSession() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [AppUpdateURLProtocol.self]
+        return URLSession(configuration: configuration)
+    }
+
+    private func release(version: String) -> Data {
+        Data("""
+        {
+          "tag_name": "\(version)",
+          "html_url": "https://github.com/teya-engineering/code-station/releases/tag/\(version)"
+        }
+        """.utf8)
+    }
+}
+
+private final class AppUpdateURLProtocol: URLProtocol, @unchecked Sendable {
+    nonisolated(unsafe) private static var responseStatus = 200
+    nonisolated(unsafe) private static var responseBody = Data()
+    nonisolated(unsafe) private static var receivedHeaders: [String: String] = [:]
+    nonisolated(unsafe) private static var receivedRequestCount = 0
+    private static let stateLock = NSLock()
+
+    static var requestCount: Int { stateLock.withLock { receivedRequestCount } }
+    static var headers: [String: String] { stateLock.withLock { receivedHeaders } }
+
+    static func prepare(status: Int, body: Data) {
+        stateLock.withLock {
+            responseStatus = status
+            responseBody = body
+            receivedHeaders = [:]
+            receivedRequestCount = 0
+        }
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        let (status, body) = Self.stateLock.withLock {
+            Self.receivedHeaders = request.allHTTPHeaderFields ?? [:]
+            Self.receivedRequestCount += 1
+            return (Self.responseStatus, Self.responseBody)
+        }
+        let response = HTTPURLResponse(url: request.url!, statusCode: status,
+                                       httpVersion: "HTTP/1.1", headerFields: nil)!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        if !body.isEmpty { client?.urlProtocol(self, didLoad: body) }
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() { }
+}


### PR DESCRIPTION
Notifies users when a newer published GitHub Release is available, while limiting automatic checks to once every five days. Dismissed releases stay available from the tools menu, and network failures do not interrupt work.

Tested with the focused AppUpdateCheckerTests suite: 6 tests passed.