### PR TITLE
Clarify app download and installation

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
     <h1 data-reveal>Your agents just got<br><em>a headquarters.</em></h1>
     <p class="reveal--delay-1" data-reveal>Run Codex and Claude Code across every project - conversation, changes, files, and terminal in one window.</p>
     <div class="actions reveal--delay-2" data-reveal>
-      <a class="btn btn--primary" href="https://github.com/teya-engineering/code-station/releases/latest">Download for macOS</a>
+      <a class="btn btn--primary" href="https://github.com/teya-engineering/code-station/releases/latest">Get the latest release</a>
       <a class="btn btn--ghost" href="https://github.com/teya-engineering/code-station">View source</a>
     </div>
   </div>
@@ -165,10 +165,10 @@
 
 <section class="band band--light band--flat" id="get-started">
   <div class="pitch">
-    <h2 data-reveal>Download it.<br><em>Open it.</em></h2>
-    <p class="reveal--delay-1" data-reveal>A signed and notarized DMG. Drag the app to Applications and launch it - no toolchain, no build step.</p>
+    <h2 data-reveal>Install it.<br><em>On your Mac.</em></h2>
+    <p class="reveal--delay-1" data-reveal>Open the latest release on GitHub and download the signed and notarized DMG. Open it, drag Teya Code Station to Applications, and launch the app - no toolchain, no build step.</p>
     <div class="actions reveal--delay-2" data-reveal>
-      <a class="btn btn--primary" href="https://github.com/teya-engineering/code-station/releases/latest">Download for macOS</a>
+      <a class="btn btn--primary" href="https://github.com/teya-engineering/code-station/releases/latest">View the latest release</a>
     </div>
   </div>
 


### PR DESCRIPTION
Send visitors to the latest GitHub release and make the signed DMG installation steps explicit on the project site.