### PR TITLE
Document release process

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Teya Code Station
 
-[Download the latest release](https://github.com/teya-engineering/code-station/releases/latest) · [Website](https://teya-engineering.github.io/code-station/) · [Contributing](CONTRIBUTING.md) · [Licence](LICENSE)
+[![Latest release](https://img.shields.io/github/v/release/teya-engineering/code-station?logo=github&label=Download)](https://github.com/teya-engineering/code-station/releases/latest) [![Website](https://img.shields.io/badge/Website-Visit-222222?logo=githubpages)](https://teya-engineering.github.io/code-station/) [![Contributing](https://img.shields.io/badge/Contributing-Guide-F05032?logo=git&logoColor=white)](CONTRIBUTING.md) [![Licence](https://img.shields.io/github/license/teya-engineering/code-station?logo=opensourceinitiative&label=Licence)](LICENSE)
 
 Teya Code Station is a macOS app for running Codex and Claude Code across local projects. It keeps conversations, files, Git changes, and terminals in one window while each coding agent continues to use its own CLI and account.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,12 @@
+# Releases
+
+Releases are started manually by tagging a commit on `main` and pushing the tag:
+
+```bash
+git tag v1.2.0
+git push origin v1.2.0
+```
+
+The `Release` GitHub Actions workflow then builds, signs, and notarizes the app. It creates a draft GitHub Release with generated release notes, the DMG, and its checksum.
+
+Review the draft in GitHub Releases, then publish it. If the workflow fails for a temporary reason, run it again from GitHub Actions and select the same tag.


### PR DESCRIPTION
Documents how maintainers trigger releases with version tags and publish the draft created by GitHub Actions. It also explains how to rerun a failed release from the same tag.